### PR TITLE
Add `admin.site = AdminSite()` to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ from django.contrib import admin
 from django_otp.admin import AdminSite
 
 OTPAdmin.enable()
+admin.site = AdminSite()
 
 urlpatterns = [
     url(r'^admin/', admin.site.urls),


### PR DESCRIPTION
The readme in section `### Using 2FA form on adminsite` was missing the line `admin.site = AdminSite()`. The desired functionality does not work without this. The example file uses this extra line. 