### PR TITLE
Fix pytest configuration and OTP widget state leakage

### DIFF
--- a/django_otp/admin.py
+++ b/django_otp/admin.py
@@ -35,6 +35,14 @@ class OTPGenerationForm(forms.ModelForm):
         """Init the instance."""
         super(OTPGenerationForm, self).__init__(*args, **kwargs)
 
+        # Ensure each form instance works with its own widget so that
+        # per-instance attributes (like the QR code ``src``) do not leak between
+        # different forms.  Django reuses the widget defined on ``Meta`` which
+        # meant subsequent forms inherited the previous state.
+        self.fields["secret"].widget = OTPGenWidget(
+            embed_script=True, attrs={"class": "secret"}
+        )
+
         def fire_gen(gen_new=True):
             return (
                 "var select=document.querySelector('#{0}');"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,3 +2,26 @@
 # coding=utf-8
 
 """Django OTP tests."""
+
+import os
+
+import django
+from django.core.management import call_command
+
+
+# Ensure Django can locate the bundled test settings before any Django modules
+# are imported.  Several tests import project modules at module import time
+# which in turn access ``django.conf.settings``.  When the environment variable
+# is not defined beforehand Django raises ``ImproperlyConfigured`` during test
+# collection.  Setting the default here mirrors what Django's ``manage.py``
+# does and keeps the tests self-contained.
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+
+# Trigger Django's setup so the app registry and translation infrastructure are
+# ready for imports performed during test collection.
+django.setup()
+
+# Prepare the database schema.  The tests rely on Django's ORM and expect the
+# built-in auth models to be present, so we run the migrations once when the
+# test suite is imported.
+call_command("migrate", run_syncdb=True, verbosity=0)


### PR DESCRIPTION
## Summary
- configure the Django test suite at import time so pytest can collect tests without ImproperlyConfigured errors
- run migrations during test bootstrap to provide the auth tables required by database-backed tests
- instantiate a fresh OTP generator widget for each admin form to keep per-instance QR code attributes from leaking

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f050f8294832ba0ad32a2c5f3f811)