### PR TITLE
Fix OTP widget translation without configured settings

### DIFF
--- a/django_otp/widgets/otp_gen.py
+++ b/django_otp/widgets/otp_gen.py
@@ -6,7 +6,7 @@
 from copy import copy
 from django.forms.widgets import TextInput
 from django.forms.utils import flatatt
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 
 from jinja2 import Environment, PackageLoader
 


### PR DESCRIPTION
## Summary
- switch the OTP generator widget to use `gettext_lazy` for its default button label to avoid accessing settings during import

## Testing
- python manage.py test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f0f6914d4832b9e49226baed164b8)